### PR TITLE
Added support for multiple platforms.

### DIFF
--- a/jekyll-site-src/_includes/drawer.html
+++ b/jekyll-site-src/_includes/drawer.html
@@ -1,4 +1,4 @@
-{% case page.categories %}
+{% case page.section %}
 {% when 'components' %}
   {% assign section = site.data.navigation.components %}
 {% when 'howto' %}
@@ -12,7 +12,7 @@
       <li class="drawer-list__item">
         <a class="drawer-list__link"
            {% if top.url %}
-             href="{{ site.url | prepend: site.github.url }}{{ site.folder }}{{ top.url }}"
+             href="{{ page.basepath }}{{ top.url }}"
            {% endif %}>
           {{ top.name }}
         </a>
@@ -33,12 +33,12 @@
                 {% endfor %}
               {% endif %}
               <li class="drawer-list__item {{ activepage }}">
-                <a class="drawer-list__link" href="{{ site.url | prepend: site.github.url }}{{ site.folder }}{{ second.url }}">{{ second.name }}</a>
+                <a class="drawer-list__link" href="{{ page.basepath }}{{ second.url }}">{{ second.name }}</a>
                 {% if second.children %}
                   <ul class="drawer-list drawer-list--sublevel">
                   {% for third in second.children %}
                     <li class="drawer-list__item thirdlevel">
-                      <a class="drawer-list__link" href="{{ site.url | prepend: site.github.url }}{{ site.folder }}{{ third.url }}">{{ third.name }}</a>
+                      <a class="drawer-list__link" href="{{ page.basepath }}{{ third.url }}">{{ third.name }}</a>
                     </li>
                   {% endfor %}
                   </ul>

--- a/jekyll-site-src/_includes/head.html
+++ b/jekyll-site-src/_includes/head.html
@@ -2,7 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no" >
-  <title>{% if page.title and page.title != site.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape }}</title>
+  <title>{% if page.title and page.title != site.title %}{{ page.title | escape }} - {% endif %}{{ page.site_title | escape }}</title>
 
   <meta itemprop="name" content="{% if page.title and page.title != site.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape }}" />
   <meta itemprop="image" content="https://material.io/static/images/simple-lp/components-share.png" />

--- a/jekyll-site-src/_includes/toolbar-nav.html
+++ b/jekyll-site-src/_includes/toolbar-nav.html
@@ -5,17 +5,17 @@ TODO(shyndman): This should be data driven.
 <nav class="toolbar-nav">
   <ul class="toolbar-nav__links">
     <li>
-      <a class="toolbar-nav-link" href="/howto/">
+      <a class="toolbar-nav-link" href="{{ page.basepath }}/howto/">
         <span class="toolbar-nav-link__text">How To</span>
       </a>
     </li>
     <li>
-      <a class="toolbar-nav-link" href="/components/">
+      <a class="toolbar-nav-link" href="{{ page.basepath }}/components/">
         <span class="toolbar-nav-link__text">Components</span>
       </a>
     </li>
     <li>
-      <a class="toolbar-nav-link" href="/contributing/">
+      <a class="toolbar-nav-link" href="{{ page.basepath }}/contributing/">
         <span class="toolbar-nav-link__text">Contributing</span>
       </a>
     </li>

--- a/jekyll-site-src/_includes/welcome.html
+++ b/jekyll-site-src/_includes/welcome.html
@@ -1,7 +1,7 @@
 <section class="welcome">
   <div class="welcome__content">
     <h1 class="welcome__title">
-      {{ site.title }}
+      {{ page.site_title }}
     </h1>
   </div>
 </section>

--- a/jekyll-site-src/_layouts/default.html
+++ b/jekyll-site-src/_layouts/default.html
@@ -2,7 +2,7 @@
 <html class="mdc-typography">
   {% include head.html %}
   <body class="mdc-typography">
-    {% include toolbar.html title=site.title %}
+    {% include toolbar.html title=page.site_title %}
 
     <div class="page-content">
       {% include drawer.html %}

--- a/jekyll-site-src/_layouts/detail.html
+++ b/jekyll-site-src/_layouts/detail.html
@@ -2,7 +2,7 @@
 <html class="mdc-typography">
   {% include head.html %}
   <body class="{{ page.layout }} {{ page.section }}">
-    {% include toolbar.html title=site.title %}
+    {% include toolbar.html title=page.site_title %}
 
     <div class="page-content">
       {% include drawer.html %}

--- a/jekyll-site-src/_layouts/landing-no-drawer.html
+++ b/jekyll-site-src/_layouts/landing-no-drawer.html
@@ -2,7 +2,7 @@
 <html class="mdc-typography">
   {% include head.html %}
   <body class="{{ page.layout }} {{ page.section }} mdc-typography">
-    {% include toolbar.html title=site.title %}
+    {% include toolbar.html title=page.site_title %}
 
     <div class="page-content">
       <article class="article">

--- a/jekyll-site-src/_layouts/landing.html
+++ b/jekyll-site-src/_layouts/landing.html
@@ -2,7 +2,7 @@
 <html class="mdc-typography">
   {% include head.html %}
   <body class="{{ page.layout }} {{ page.section }} mdc-typography">
-    {% include toolbar.html title=site.title no_shadow=true %}
+    {% include toolbar.html title=page.site_title no_shadow=true %}
 
     <div class="page-content">
       {% include drawer.html %}

--- a/scripts/build
+++ b/scripts/build
@@ -8,25 +8,24 @@ const fs = require('fs-extra');
 const path = require('path');
 const reporter = require('./lib/reporter');
 const webpack = require('webpack');
-const { ASSET_EXTENSIONS, JEKYLL_CONFIG_PATH, PLATFORM_CONFIG_PATH, BuildDir, FilePattern } = require('./lib/project-paths');
+const { ASSET_EXTENSIONS, JEKYLL_CONFIG_PATH, BuildDir } = require('./lib/project-paths');
 const { JekyllConfiguration } = require('./lib/jekyll-config');
-const { JekyllFile } = require('./lib/jekyll-file');
+const { PlatformSite } = require('./lib/platform-site');
 const { addWatchToWebpackConfig, setupFileWatches } = require('./lib/watch');
 const { execSync } = require('child_process');
 const { initCli } = require('./lib/cli');
-const { processJekyllFile, processSupplementaryDirectory } = require('./lib/processors');
-const { sync: globSync } = require('glob');
+const { processJekyllFile, processDocsDirectory } = require('./lib/processors');
 
 
 // Parses and validates command line arguments.
 const cli = initCli();
-const platformPath = cli.input[0];
+const platformSites = cli.input.map((repoPath) => new PlatformSite(repoPath));
 
 // Ensure that the working directory is the project root
 const projectRootPath = path.join(__dirname, '..');
 process.chdir(projectRootPath);
 
-reporter.step('Cleaning...', () => {
+reporter.step('Cleaning', () => {
   try {
     assert(process.cwd() == projectRootPath);
     fs.removeSync(BuildDir.STAGE);
@@ -39,25 +38,25 @@ reporter.step('Cleaning...', () => {
 
 fs.copySync(BuildDir.JEKYLL, BuildDir.STAGE);
 
-reporter.step('Processing Jekyll files...', () => {
-  const files = globSync(path.join(platformPath, FilePattern.JEKYLL_FILES))
-      .map((filePath) => JekyllFile.readFromPath(filePath, platformPath))
-  files.forEach(processJekyllFile);
+reporter.step('Processing Jekyll files', () => {
+  platformSites.forEach((site) => {
+    site.files.forEach((f) => processJekyllFile(site, f));
+  });
 });
 
-reporter.step('Copying supplementary directories...', () => {
-  const docsDirectoryPaths = globSync(
-      path.join(platformPath, FilePattern.DOCS_DIRS));
-  docsDirectoryPaths.forEach((docsDirPath) =>
-      processSupplementaryDirectory(platformPath, docsDirPath));
+reporter.step('Copying supplementary directories', () => {
+  platformSites.forEach((site) => {
+    site.directoryPaths.forEach((d) => processDocsDirectory(site, d));
+  });
 });
 
-const config = reporter.step('Preparing configuration...', () => {
-  return new JekyllConfiguration(path.join(BuildDir.STAGE, JEKYLL_CONFIG_PATH))
-      .addPlatform(path.join(platformPath, PLATFORM_CONFIG_PATH));
+const config = reporter.step('Preparing configuration', () => {
+  const c = new JekyllConfiguration(path.join(BuildDir.STAGE, JEKYLL_CONFIG_PATH));
+  platformSites.forEach((site) => c.addPlatformConfig(site.config));
+  return c;
 });
 
-reporter.step('Building assets...', () => {
+reporter.step('Building assets', () => {
   // TODO(shyndman): Periodically check if we can uncomment this. There's some
   // noisy deprecation deep in Webpack.
   process.noDeprecation = true;
@@ -79,7 +78,7 @@ reporter.step('Building assets...', () => {
 }, { noCheck: true });
 
 function buildJekyll() {
-  reporter.step('Building Jekyll site...', () => {
+  reporter.step('Building Jekyll site', () => {
     // Write out the merged config.
     config.write(path.join(BuildDir.STAGE, JEKYLL_CONFIG_PATH));
 

--- a/scripts/lib/jekyll-config.js
+++ b/scripts/lib/jekyll-config.js
@@ -9,8 +9,7 @@ class JekyllConfiguration {
     this.platformConfigs = new Map();
   }
 
-  addPlatform(platformConfigPath) {
-    const platformConfig = readYaml(platformConfigPath);
+  addPlatformConfig(platformConfig) {
     this.validatePlatformConfig_(platformConfig);
     this.platformConfigs.set(platformConfig.basepath, platformConfig);
 
@@ -44,13 +43,17 @@ class JekyllConfiguration {
     for (const [basepath, platformConfig] of this.platformConfigs) {
       mergedConfig['defaults'].push({
         scope: {
-          basepath,
+          path: this.sanitizeScopePath_(basepath),
         },
         values: platformConfig,
       });
     }
 
     return mergedConfig;
+  }
+
+  sanitizeScopePath_(path) {
+    return path.trim().replace(/^\/?([^/]*)\//g, '$1');
   }
 }
 

--- a/scripts/lib/platform-site.js
+++ b/scripts/lib/platform-site.js
@@ -1,0 +1,41 @@
+const fs = require('fs-extra');
+const path = require('path');
+const yaml = require('js-yaml');
+const { JekyllFile } = require('./jekyll-file');
+const { PLATFORM_CONFIG_PATH, FilePattern } = require('./project-paths');
+const { sync: globSync } = require('glob');
+
+
+class PlatformSite {
+  constructor(repoPath) {
+    this.repoPath = repoPath;
+    this.config = readYaml(path.join(repoPath, PLATFORM_CONFIG_PATH));
+    this.files_ = null;
+  }
+
+  get basepath() {
+    return this.config.basepath;
+  }
+
+  get files() {
+    if (!this.files_) {
+      this.files_ = globSync(path.join(this.repoPath, FilePattern.JEKYLL_FILES))
+          .map((filePath) => JekyllFile.readFromPath(filePath, this.repoPath));
+    }
+    return this.files_;
+  }
+
+  get directoryPaths() {
+    return globSync(path.join(this.repoPath, FilePattern.DOCS_DIRS));
+  }
+}
+
+
+function readYaml(yamlPath) {
+  return yaml.safeLoad(fs.readFileSync(yamlPath));
+}
+
+
+module.exports = {
+  PlatformSite,
+};

--- a/scripts/lib/processors.js
+++ b/scripts/lib/processors.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra');
 const { BuildDir } = require('./project-paths');
 
 
-function processJekyllFile(file) {
+function processJekyllFile(platformSite, file) {
   if (!file.isValidJekyll) {
     return false;
   }
@@ -13,14 +13,14 @@ function processJekyllFile(file) {
     file.basename = 'index.md';
   }
 
-  file.path = path.resolve(BuildDir.STAGE, file.relative);
+  file.path = path.resolve(path.join(BuildDir.STAGE, platformSite.basepath), file.relative);
   file.basedir = BuildDir.STAGE;
   file.write();
 }
 
-function processSupplementaryDirectory(docsRepoPath, docsDirPath) {
-  const relativePath = path.relative(docsRepoPath, docsDirPath);
-  const newPath = path.resolve(BuildDir.STAGE, relativePath);
+function processDocsDirectory(platformSite, docsDirPath) {
+  const relativePath = path.relative(platformSite.repoPath, docsDirPath);
+  const newPath = path.resolve(path.join(BuildDir.STAGE, platformSite.basepath), relativePath);
   fs.ensureDirSync(newPath);
   fs.copySync(docsDirPath, newPath);
 }
@@ -28,5 +28,5 @@ function processSupplementaryDirectory(docsRepoPath, docsDirPath) {
 
 module.exports = {
   processJekyllFile,
-  processSupplementaryDirectory,
+  processDocsDirectory,
 };

--- a/scripts/lib/reporter.js
+++ b/scripts/lib/reporter.js
@@ -9,7 +9,7 @@ class Reporter {
   }
 
   step(stepLabel, runStep, { noCheck } = { noCheck: false }) {
-    this.log_(chalk.cyan(stepLabel) + (noCheck ? '\n' : ''));
+    this.log_(chalk.cyan(stepLabel) + '...' + (noCheck ? '\n' : ''));
     this.inStep_ = true;
 
     try {


### PR DESCRIPTION
Introduces the ability to generate the site from multiple platform directories (ie. mdc repos). Each repo must have an .mdc-docsite.yaml configuration file, which provides platform-wide values that are decorated into Jekyll's `page` variable.

I introduced the `JekyllConfiguration` for creating a single merged configuration file (using [Jekyll scopes](https://jekyllrb.com/docs/configuration/#front-matter-defaults)).

Another new class, `PlatformSite` , hides away some of the ugliness of dealing with paths and the construction of `JekyllFile`s.