### PR TITLE
Fix Bundler::GemfileNotFound issue

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -107,7 +107,7 @@ function buildJekyll() {
     }
 
     const jekyllEnv = Object.assign({}, process.env, {
-      BUNDLE_GEMFILE: path.join(projectRootPath, 'GEMFILE'),
+      BUNDLE_GEMFILE: path.join(projectRootPath, 'Gemfile'),
     });
     execSync(`bundle exec jekyll build \
         --source ${BuildDir.STAGE} \


### PR DESCRIPTION
This change fixes the following error I got when trying to build the `ember-material-components-web` documentation.

```
Building Jekyll site...Bundler::GemfileNotFound: /home/kerrick/Developer/material-components-site-generator/GEMFILE not found
  /home/kerrick/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/definition.rb:31:in `build'
  /home/kerrick/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler.rb:128:in `definition'
  /home/kerrick/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler.rb:94:in `setup'
  /home/kerrick/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bundler-1.14.6/lib/bundler/setup.rb:20:in `<top (required)>'
  /home/kerrick/.rbenv/versions/2.4.1/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  /home/kerrick/.rbenv/versions/2.4.1/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
/home/kerrick/Developer/material-components-site-generator/scripts/lib/reporter.js:36
      throw e;
```