### PR TITLE
support multi-line underlines for active link text

### DIFF
--- a/jekyll-site-src/_css_src/components/_drawer.scss
+++ b/jekyll-site-src/_css_src/components/_drawer.scss
@@ -29,17 +29,9 @@
       @include link-styles {
         color: $black;
         font-weight: 500;
-        text-decoration: none;
-      }
-
-      &::before {
-        content: '';
-        position: absolute;
-
-        bottom: 4px;
-        left: 0;
-        right: 0;
-        border-bottom: 1px solid $accent-color;
+        text-decoration: underline;
+        text-decoration-color: $accent-color;
+        text-underline-position: under;
       }
     }
   }


### PR DESCRIPTION
This style change renders multi-line underlines in the drawer list (border bottom only displays correctly for single line spans).

Before:

![image](https://user-images.githubusercontent.com/4650077/30296948-ffa69b66-9713-11e7-81eb-16192fff62a7.png)

After:

![image](https://user-images.githubusercontent.com/4650077/30296957-07e5cb80-9714-11e7-8220-06602d12d79d.png)
