### PR TITLE
Fail builds on broken links.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "codemirror": "^5.25.0",
     "lodash": "^4.17.4",
     "material-components-web": "^0.8.0",
-    "reset-css": "^2.2.0"
+    "reset-css": "^2.2.0",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.7",

--- a/scripts/lib/patterns.js
+++ b/scripts/lib/patterns.js
@@ -43,9 +43,25 @@ function newSrcPattern() {
   return /src=["']([^'"]+)["']/g;
 }
 
+/**
+ * Returns a regular expression for matching Markdown code blocks.
+ */
+function newMarkdownCodeBlockPattern() {
+  return /^(([ \t]*`{3,4})([^\n]*)([\s\S]+?)(^[ \t]*\2))/gm;
+}
+
+/**
+ * Returns a regular expression that matches asset file paths.
+ */
+function newAssetPathPattern() {
+  return /\.(mp4|m4v|png|svg|jpe?g|gif)$/ig;
+}
+
 
 module.exports = {
-  newMarkdownLinkPattern,
+  newAssetPathPattern,
   newHrefPattern,
+  newMarkdownCodeBlockPattern,
+  newMarkdownLinkPattern,
   newSrcPattern,
 };

--- a/scripts/lib/reporter.js
+++ b/scripts/lib/reporter.js
@@ -59,14 +59,21 @@ class Reporter {
   }
 
   fileDestinationConflict(destPath, srcPath1, srcPath2) {
-    console.log('filePathConflict', arguments);
-
     if (this.inStep_) {
       this.logLine_();
     }
 
     this.logLine_(chalk.bgRed('Error:'));
     this.logLine_(`${ chalk.yellow(srcPath1) } and \n${ chalk.yellow(srcPath2) } both attempting to write to ${ chalk.yellow(destPath) }`);
+  }
+
+  brokenLink(href, filePath) {
+    if (this.inStep_) {
+      this.logLine_();
+    }
+
+    this.logLine_(chalk.black.bgRed('Error:'));
+    this.logLine_(`Broken link ${ chalk.yellow(href) } in ${ chalk.yellow(filePath) }`);
   }
 
   fatal(err) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3548,6 +3548,10 @@ uuid@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
+uuid@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"


### PR DESCRIPTION
* Changed handling of unknown links from ignoring to failing.
* Excludes code blocks during link processing. This allows arbitrary URLs to
  exist in example code without issue.
* Added UUIDs to link and code template variables to avoid collisions with
  user-supplied variables.
* Added styled reporting of broken links.