### PR TITLE
Excludes inline code from consideration during broken link checking.

### DIFF
--- a/scripts/lib/documentation-file.js
+++ b/scripts/lib/documentation-file.js
@@ -178,7 +178,7 @@ class DocumentationFile extends JekyllFile {
     const codeBlockVars = new Map();
 
     // Replace code blocks with variable references
-    contents = contents.replace(patterns.newMarkdownCodeBlockPattern(), (match) => {
+    contents = contents.replace(patterns.newMarkdownCodePattern(), (match) => {
       const varRef = `{{ code_${ uuid() } }}`;
       codeBlockVars.set(varRef, match);
       return varRef;

--- a/scripts/lib/patterns.js
+++ b/scripts/lib/patterns.js
@@ -44,10 +44,38 @@ function newSrcPattern() {
 }
 
 /**
- * Returns a regular expression for matching Markdown code blocks.
+ * Returns a regular expression for matching Markdown code (blocks and inline).
  */
-function newMarkdownCodeBlockPattern() {
-  return /^(([ \t]*`{3,4})([^\n]*)([^]+?)(^[ \t]*\2))/gm;
+function newMarkdownCodePattern() {
+  return new RegExp([
+    // CODE BLOCK
+    '^(',
+      // Leading space, followed by 3 or 4 backticks
+      '([ \\t]*`{3,4})',
+      // Match to the end of the first line
+      '([^\\n]*)',
+      // Lazily match everything ([^] is negation of empty set)...
+      '([^]+?)',
+      // ...until we hit the the same number of backticks as captured up front.
+      '(^[ \\t]*\\2)',
+    ')|',
+
+    // INLINE CODE
+    '(',
+      // Starting backtick
+      '`',
+      // Zero or more non-empty lines (inline code can be split across lines,
+      // as long as they aren't blank)
+      '(',
+        '\\n(^[^`\\n]+$)',
+      ')*',
+      // Followed by one character of anything but a backtick (`` isn't valid)
+      '[^`]',
+      // Then lazily match any character on the current line until the ending
+      // backtick.
+      '.*?`',
+    ')',
+  ].join(''), 'gm')
 }
 
 /**
@@ -61,7 +89,7 @@ function newAssetPathPattern() {
 module.exports = {
   newAssetPathPattern,
   newHrefPattern,
-  newMarkdownCodeBlockPattern,
+  newMarkdownCodePattern,
   newMarkdownLinkPattern,
   newSrcPattern,
 };

--- a/test/code-patterns.test.js
+++ b/test/code-patterns.test.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { assert } = require('chai');
+const { newMarkdownCodePattern } = require('../scripts/lib/patterns');
+
+
+suite('patterns');
+
+test('Matches inline code embedded in a sentence', () => {
+  assert.match(
+      'This is a paragraph containing `inline code`, and more!',
+      newMarkdownCodePattern());
+});
+
+test('Matches lonely line code', () => {
+  assert.match('`some code`', newMarkdownCodePattern());
+});
+
+test('Matches inline code split across lines', () => {
+  assert.match(`
+      \`
+      some
+      code
+      across
+      lines
+      \`
+    `, newMarkdownCodePattern());
+});
+
+test('Does not match inline code split across lines with empty lines', () => {
+  assert.notMatch(`
+      \`
+      some
+      code
+
+      across
+      lines
+      \`
+  `, newMarkdownCodePattern());
+});
+
+test('Matches code blocks with a language specifier', () => {
+  assert.match(`
+      \`\`\`html
+      some
+      code
+
+      across
+      lines
+      \`\`\`
+  `, newMarkdownCodePattern());
+});
+
+test('Matches code blocks without a language specifier', () => {
+  assert.match(`
+      \`\`\`
+      some
+      code
+
+      across
+      lines
+      \`\`\`
+  `, newMarkdownCodePattern());
+});
+
+test('Matches code blocks with inconsistent leading whitespace', () => {
+  assert.match(`
+      \`\`\`
+      some
+      code
+
+      across
+      lines
+           \`\`\`
+  `, newMarkdownCodePattern());
+});
+


### PR DESCRIPTION
Extends the existing regular expression to handle inline code. Tests are a little weak as could be checking the capture. I'll improve them now if someone thinks its worth it.