### PR TITLE
Ignore hidden files when generating docs.

### DIFF
--- a/scripts/lib/platform-site.js
+++ b/scripts/lib/platform-site.js
@@ -65,7 +65,7 @@ class PlatformSite {
       this.files_ = globSync(path.join(this.repoPath, FilePattern.JEKYLL_FILES), GLOB_OPTIONS)
           .map((filePath) => DocumentationFile.readFromPath(filePath, this.repoPath))
           .filter((file) => file.isValidJekyll)
-          .filter((file) => (file.path.indexOf('/.') == -1 && file.path.indexOf('.') != 0));
+          .filter((file) => (file.path.indexOf('/.') === -1 && file.path.indexOf('.') !== 0));
     }
 
     return this.files_;

--- a/scripts/lib/platform-site.js
+++ b/scripts/lib/platform-site.js
@@ -64,7 +64,8 @@ class PlatformSite {
     if (!this.files_) {
       this.files_ = globSync(path.join(this.repoPath, FilePattern.JEKYLL_FILES), GLOB_OPTIONS)
           .map((filePath) => DocumentationFile.readFromPath(filePath, this.repoPath))
-          .filter((file) => file.isValidJekyll);
+          .filter((file) => file.isValidJekyll)
+          .filter((file) => (file.path.indexOf('/.') == -1 && file.path.indexOf('.') != 0));
     }
 
     return this.files_;


### PR DESCRIPTION
This avoids site generation failures due to picking up files that might have valid yaml preambles, but aren't intended to be picked up by the website, e.g. `.github` configuration files.

This is required to get the docsite generation working for https://github.com/material-components/material-components-ios

Fixes the following error which is a result of a `.github` file having an undefined `title` field in its preamble:

```
TypeError: Cannot read property 'localeCompare' of undefined
    at node.children.sort (/Volumes/BuildData/tmpfs/src/github/repo/docsite-generator/scripts/lib/section-navigation.js:133:19)
    at Array.sort (native)
    at SectionNavigation.sort_ (/Volumes/BuildData/tmpfs/src/github/repo/docsite-generator/scripts/lib/section-navigation.js:130:19)
    at SectionNavigation.sort_ (/Volumes/BuildData/tmpfs/src/github/repo/docsite-generator/scripts/lib/section-navigation.js:137:12)
    at SectionNavigation.sort_ (/Volumes/BuildData/tmpfs/src/github/repo/docsite-generator/scripts/lib/section-navigation.js:137:12)
    at SectionNavigation.sort_ (/Volumes/BuildData/tmpfs/src/github/repo/docsite-generator/scripts/lib/section-navigation.js:137:12)
    at new SectionNavigation (/Volumes/BuildData/tmpfs/src/github/repo/docsite-generator/scripts/lib/section-navigation.js:38:10)
    at PlatformSite.buildNavigation_ (/Volumes/BuildData/tmpfs/src/github/repo/docsite-generator/scripts/lib/platform-site.js:172:26)
    at PlatformSite.prepareForBuild (/Volumes/BuildData/tmpfs/src/github/repo/docsite-generator/scripts/lib/platform-site.js:103:10)
    at platformSites.forEach (/Volumes/BuildData/tmpfs/src/github/repo/docsite-generator/scripts/build:60:10)
```